### PR TITLE
Updated code to work with Windows MSYS2, and added build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ enable_testing()
 set(CMAKE_BUILD_DIRECTORY build)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 file(GLOB Voropp_SRC_DIRS "voro++-0.4.6/src")
 find_package(Boost COMPONENTS math_c99l REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ enable_testing()
 
 set(CMAKE_BUILD_DIRECTORY build)
 
-set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 file(GLOB Voropp_SRC_DIRS "voro++-0.4.6/src")
-file(GLOB Boost_LIB_DIRS "/lnm/lib/Q1_2015/boost/lib")
+find_package(Boost COMPONENTS math_c99l REQUIRED)
 
-link_directories(${Boost_LIB_DIRS} ${Voropp_SRC_DIRS})
+link_directories(${Voropp_SRC_DIRS})
 
 file(GLOB SOURCES "src/*.cpp")
 add_executable(voronoi ${SOURCES})
@@ -55,7 +55,8 @@ add_custom_target(
    COMMAND make -C ${CMAKE_CURRENT_SOURCE_DIR}/voro++-0.4.6/
 )
 
-target_link_libraries(voronoi boost_math_c99l boost_filesystem boost_system voro++)
+target_link_libraries(voronoi Boost::math_c99l voro++)
+target_include_directories(voronoi PUBLIC ${Boost_INCLUDE_DIRS})
 add_dependencies(voronoi voropp)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ regeneration, and elastic properties. Phys. Rev. E - Stat. Nonlinear, Soft Matte
     $ make
     $ cd ..
 
+## Building on Windows
+
+- Clone this repository somewhere (e.g. `git clone https://github.com/bionetgen/bionetgen /C/Users/user/Desktop/bionetgen`)
+- Install [MSYS2](https://www.msys2.org/)
+  - This gives access to a Linux-like toolchains (i.e. `make`, `perl`, and `boost`)
+- Boot into an `MSYS2_MinGW64` terminal
+  - Note: the reason this guide uses MinGW64 under MSYS2 is because MSYS2 is more regularly updated than MinGW, but MinGW can be used to create standalone binaries
+- Install `cmake`, `make`, `gcc`, `g++`, and `boost`
+  - e.g. `pacman -S mingw-w64-x86_64-cmake make mingw-w64-x86_64-gcc mingw-w64-x86_64-boost`
+- Switch to the cloned repository (e.g. `cd /C/Users/user/Desktop/bionetgen`)
+- Build a `voroni.exe` with static linking, so it can be used on any Windows computer, with:
+
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static"
+    cmake --build .
+
 ## Usage
     $ ./build/voronoi config.json
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,23 @@ Bionetgen is a brief C++ tool to create fiber networks that follow the fiber len
 regeneration, and elastic properties. Phys. Rev. E - Stat. Nonlinear, Soft Matter Phys. 82(5), 2 (2010).
 
 
+## Usage
+
+    $ ./build/voronoi config.json
+
+
+## Configuration
+
+Use the config.json file to set parameters for the algorithm.
+
+The *main* operation mode can be selected by changing the values of *generate* and *simulate* in the config file. If only generate is true, a voronoi geometry will be generated and saved as the output. If simulate is also true, simulated annealing will additionally be performed before the geometry is saved to the output files. If only simulate is true, a previously saved geometry will be read from the input files, simulated annealing will be perfomed and the result will be saved to the output files.
+
+
 ## Building
+
+### Building on Linux
+
+Assumes you have `cmake`, `make`, and a C/C++ compiler installed.
 
     $ mkdir build
     $ cd build
@@ -14,7 +30,8 @@ regeneration, and elastic properties. Phys. Rev. E - Stat. Nonlinear, Soft Matte
     $ make
     $ cd ..
 
-## Building on Windows
+
+### Building on Windows
 
 These build instructions use the MinGW64 part of [MSYS2](https://www.msys2.org/), which provides the necessary tools (i.e. `cmake`, `make`, `g++`, and `boost`). It generates a standalone executable that only depends on Windows' core libraries.
 
@@ -44,14 +61,105 @@ cmake --build .
 ldd voronoi.exe
 ```
 
-## Usage
-    $ ./build/voronoi config.json
+#### Developing on Windows (Visual Studio 2022)
 
-## Configuration
+- Confirm you can build `voronoi.exe` manually using MSYS etc. (above)
+- In Visual Studio 2022, open `bionetgen` as a folder project ("Open as Local Folder" from the splash screen)
+- Visual Studio should detect that it's a CMake project and suggest `Open CMake Settings Editor`
+- Open the CMake settings editor and save `Ctrl+S`, which should create a `CMakeSettings.json` file
+- Right-click the `CMakeSettings.json` file and `Open With` the JSON editor (rather than the default GUI editor)
+- Replace the original content with this custom JSON (it configures Visual Studio to use MSYS2 to build the C++)
 
-Use the config.json file to set parameters for the algorithm.
+```json
+{
+  "configurations": [
+    {
+      "environments": [
+        {
+          "MINGW64_ROOT": "C:/msys64/mingw64",
+          "BIN_ROOT": "${env.MINGW64_ROOT}/bin",
+          "FLAVOR": "x86_64-w64-mingw32",
+          "TOOLSET_VERSION": "12.2.0",
+          "INCLUDE": "${env.MINGW64_ROOT}/include;${env.MINGW64_ROOT}/include/c++/${env.TOOLSET_VERSION};${env.MINGW64_ROOT}/include/c++/${env.TOOLSET_VERSION}/tr1;${env.MINGW64_ROOT}/include/c++/${env.TOOLSET_VERSION}/${env.FLAVOR}",
+          "MINGW_PREFIX": "C:/msys64/mingw64",
+          "MINGW_CHOST": "x86_64-w64-mingw32",
+          "MINGW_PACKAGE_PREFIX": "mingw-w64-x86_64",
+          "MSYSTEM": "MINGW64",
+          "MSYSTEM_CARCH": "x64_64",
+          "MSYSTEM_PREFIX": "C:/msys64/mingw64",
+          "MSYSTEM_CHOST": "x86_64-w64-mingw32",
+          "SHELL": "${env.MINGW_PREFIX}/../usr/bin/bash",
+          "TEMP": "${env.MINGW_PREFIX}/../tmp",
+          "TMP": "${env.TEMP}",
+          "PATH": "${env.MINGW_PREFIX}/bin;${env.MINGW_PREFIX}/../usr/local/bin;${env.MINGW_PREFIX}/../usr/bin;${env.MINGW_PREFIX}/../bin;${env.PATH}",
+          "environment": "mingw_64"
+        }
+      ],
+      "name": "Mingw64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [
+        "mingw_64",
+        "msvc_x64_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "intelliSenseMode": "linux-gcc-x64",
+      "variables": [
+        {
+          "name": "CMAKE_C_COMPILER",
+          "value": "${env.BIN_ROOT}/gcc.exe"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "${env.BIN_ROOT}/g++.exe"
+        }
+      ]
+    }
+  ]
+}
+```
 
-The *main* operation mode can be selected by changing the values of *generate* and *simulate* in the config file. If only generate is true, a voronoi geometry will be generated and saved as the output. If simulate is also true, simulated annealing will additionally be performed before the geometry is saved to the output files. If only simulate is true, a previously saved geometry will be read from the input files, simulated annealing will be perfomed and the result will be saved to the output files.
+- Save the JSON, which should cause Visual Studio to reconfigure the project
+- Reconfiguration should succeed. The `Output` tab (bottom of Visual Studio)
+  will print something like "Configuration Complete". If it doesn't, there's
+  probably something wrong in the JSON. Good guesses are:
+
+    - `MINGW64_ROOT` is wrong, because you installed MSYS2 somewhere else. Find
+       where it's installed and change it in the JSON to match the actual location
+    - `TOOLSET_VERSION` is wrong, because your MSYS2 installed a slightly different
+      version of C++. This makes later strings like (e.g.) `${env.MINGW64_ROOT}/include/c++/${env.TOOLSET_VERSION}`
+      incorrect. The solution is to browse through your MSYS2 install to find what
+      version string to use (look at how it's used in the example)
+
+- In Visual Studio, at the top of the UI where it says "Select Startup Item", click
+  the little dropdown arrow and select `voronoi.exe`. This will cause (e.g.) `Ctrl+B`
+  to build `voronoi.exe` and (e.g.) `F5` to build+debug `voronoi.exe`
+
+- If you want to run `voronoi.exe` with arguments (e.g. a file, input configuration, etc.)
+  then you will need to tell Visual Studio which arguments to use. Here's a guide:
+  https://stackoverflow.com/questions/30104520/adding-command-line-arguments-to-project
+
+- (example of `launch.vs.json` making the run command provide an argument):
+
+```json
+{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "voronoi.exe",
+      "name": "voronoi.exee",
+      "args": ["C:\\some\\path\\to\\config.json"]
+    }
+  ]
+}
+```
 
 ### Publications
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,31 @@ regeneration, and elastic properties. Phys. Rev. E - Stat. Nonlinear, Soft Matte
 
 ## Building on Windows
 
-- Clone this repository somewhere (e.g. `git clone https://github.com/bionetgen/bionetgen /C/Users/user/Desktop/bionetgen`)
-- Install [MSYS2](https://www.msys2.org/)
-  - This gives access to a Linux-like toolchains (i.e. `make`, `perl`, and `boost`)
-- Boot into an `MSYS2_MinGW64` terminal
-  - Note: the reason this guide uses MinGW64 under MSYS2 is because MSYS2 is more regularly updated than MinGW, but MinGW can be used to create standalone binaries
-- Install `cmake`, `make`, `gcc`, `g++`, and `boost`
-  - e.g. `pacman -S mingw-w64-x86_64-cmake make mingw-w64-x86_64-gcc mingw-w64-x86_64-boost`
-- Switch to the cloned repository (e.g. `cd /C/Users/user/Desktop/bionetgen`)
-- Build a `voroni.exe` with static linking, so it can be used on any Windows computer, with:
+These build instructions use the MinGW64 part of [MSYS2](https://www.msys2.org/), which provides the necessary tools (i.e. `cmake`, `make`, `g++`, and `boost`). It generates a standalone executable that only depends on Windows' core libraries.
 
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static"
-    cmake --build .
+The reason this guide uses MinGW64 under MSYS2, despite MSYS2 generally being considered to be more modern, is because MinGW can be used to create standalone executables that ultimately do not depend on either MSYS2 or MinGW64 to run them.
+
+- Install [MSYS2](https://www.msys2.org/)
+- Clone this repository onto your computer
+- Boot into an `MSYS2_MinGW64` terminal
+- Go through these commands:
+
+```bash
+# install `cmake`, `make`, `gcc`, `g++`, and `boost`
+pacman -S mingw-w64-x86_64-cmake make mingw-w64-x86_64-gcc mingw-w64-x86_64-boost
+
+# change to the cloned repository
+cd /C/Users/user/Desktop/bionetgen
+
+# build with static linking
+mkdir build
+cd build
+cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static"
+cmake --build .
+
+# check voronoi.exe exists
+stat voronoi.exe
+```
 
 ## Usage
     $ ./build/voronoi config.json

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ cd build
 cmake .. -DCMAKE_EXE_LINKER_FLAGS="-static"
 cmake --build .
 
-# check voronoi.exe exists
-stat voronoi.exe
+# check voronoi.exe exists, and that it only depends on Windows libraries
+#
+# (i.e. every library it lists should be in /C/Windows)
+ldd voronoi.exe
 ```
 
 ## Usage

--- a/src/config-loader.cpp
+++ b/src/config-loader.cpp
@@ -34,17 +34,19 @@
 
 #include "./voronoi.cpp"
 
+#include <filesystem>
+
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/property_tree/json_parser.hpp>
 class ConfigLoader
 {
     boost::property_tree::ptree _root;
-    boost::filesystem::path _config_path;
+    std::filesystem::path _config_path;
 
 public:
     void load(std::string path)
     {
-        this->_config_path = boost::filesystem::path(path).parent_path();
+        this->_config_path = std::filesystem::path(path).parent_path();
         boost::property_tree::read_json(path, this->_root);
     }
     void configure(Voronoi& voronoi)

--- a/src/voronoi.cpp
+++ b/src/voronoi.cpp
@@ -36,11 +36,11 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 #include <random>
 #include <chrono>
 #include <map>
 #include <set>
-#include <boost/filesystem.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/lexical_cast.hpp>
@@ -50,14 +50,15 @@
 // #include "../lib/lib_vec.hpp"
 
 const double one_third = 1.0 / 3.0;
+using uint = unsigned;
 
 class Voronoi
 {
   bool generate_;
   bool simulate_;
   uint mode_;
-  boost::filesystem::path outputPrefix_;
-  boost::filesystem::path inputPrefix_;
+  std::filesystem::path outputPrefix_;
+  std::filesystem::path inputPrefix_;
   std::vector<double> boxSize_;
   std::vector<double> boxOrigin_;
   double seed_;
@@ -100,16 +101,16 @@ class Voronoi
   unsigned int p_num_bins_cosines;
 
 public:
-  void configure(boost::filesystem::path config_path, boost::property_tree::ptree config)
+  void configure(std::filesystem::path config_path, boost::property_tree::ptree config)
   {
-    this->outputPrefix_ = boost::filesystem::path(config_path) / boost::filesystem::path(config.get<std::string>("output-prefix"));
+    this->outputPrefix_ = std::filesystem::path(config_path) / std::filesystem::path(config.get<std::string>("output-prefix"));
     if (this->outputPrefix_.has_parent_path())
-      if (!boost::filesystem::exists(this->outputPrefix_.parent_path()))
-        boost::filesystem::create_directory(this->outputPrefix_.parent_path());
-    this->inputPrefix_ = boost::filesystem::path(config_path) / boost::filesystem::path(config.get<std::string>("input-prefix"));
+      if (!std::filesystem::exists(this->outputPrefix_.parent_path()))
+        std::filesystem::create_directory(this->outputPrefix_.parent_path());
+    this->inputPrefix_ = std::filesystem::path(config_path) / std::filesystem::path(config.get<std::string>("input-prefix"));
     if (this->inputPrefix_.has_parent_path())
-      if (!boost::filesystem::exists(this->inputPrefix_.parent_path()))
-        boost::filesystem::create_directory(this->inputPrefix_.parent_path());
+      if (!std::filesystem::exists(this->inputPrefix_.parent_path()))
+        std::filesystem::create_directory(this->inputPrefix_.parent_path());
 
     this->seed_ = config.get<double>("seed");
     this->voronoiParticleCount_ = config.get<uint>("particles");


### PR DESCRIPTION
Thanks for publishing this library :)

I am working with a PhD student who would like to try the code out on their Windows laptop. I gave it a swing with the aim of creating a standalone `voronoi.exe` file that can be sent to other people who don't necessarily have any libraries, toolchains, MinGW, etc. installed

The changeset required the following:

- I switched the hard-coded Boost path to using `find_packages`, because MinGW64 under MSYS2 installs boost somewhere different.
- I updated from C++11 to C++17, in order to have access to the `<filesystem>` library (explained later)
- `boost::filesystem`, despite appearing to be linked fine in the `CMakeLists.txt` file, had linking errors on MinGW64. Couldn't figure out why. Probably something is mis-linking. I dropped `boost::filesystem` from the CMake build requirements and switched all uses of `boost::filesystem` for `std::filesystem`. `std::filesystem` is based on `boost::filesystem` and can essentially be used as a drop-in replacement.
- I added `using uint = unsigned;` to an implementation file. `uint` isn't standard, `unsigned` and `unsigned int` are. I used a `using`, for now, to reduce how big the diff is (a better fix would be to switch it throughout the file)
- I added a `Building on Windows` section to the README which explains in a very direct way how to create a `voronoi.exe` binary that does no depend on any runtime libraries. The reason it's so specific is so that less-experienced users can just follow it step-by-step